### PR TITLE
Allow Running on Newer Framework Versions

### DIFF
--- a/dotnet-json/dotnet-json.csproj
+++ b/dotnet-json/dotnet-json.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>dotnet_json</RootNamespace>
+    <RollForward>LatestMajor</RollForward>
     
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
I'd like to be able to run this tool on newer versions of the framework, such as .NET 5-RC2.  This PR allows running the tool on versions 3.1.0+